### PR TITLE
Add crosscompilation for scala 2.11

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: scala
 
 scala:
+- 2.11.12
 - 2.12.4
 
 jdk:

--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ name := "fs2-blobstore"
 
 inThisBuild(Seq(
   scalaVersion := "2.12.4",
+  crossScalaVersions := Seq("2.11.12", "2.12.4"),
   organization := "com.lendup.fs2-blobstore"
 ))
 


### PR DESCRIPTION
Cross compilation adds very little maintenance but might help people to take advantage of your work (e.g. the library I work on is not quite up to the bleeding edge yet but I'd love to be able to use this and said library in the same project).

`sbt-rig` should just pick up these changes and start publishing artifacts, from what I can tell. Happy to add a few commits if I've missed anything