### PR TITLE
migrating s3 put to tm upload

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.3.0
+======
+* Update S3Store to use s3's TransferManager.upload during put [#28](https://github.com/lendup/fs2-blobstore/pull/28)
+
 v0.2.2
 ======
 * Update fs2 to 1.0.0, Scala to 2.12.7 [#24](https://github.com/lendup/fs2-blobstore/pull/24)

--- a/box/src/main/scala/blobstore/box/BoxStore.scala
+++ b/box/src/main/scala/blobstore/box/BoxStore.scala
@@ -27,7 +27,7 @@ import fs2.{Sink, Stream}
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-case class BoxStore[F[_]](api: BoxAPIConnection, rootFolderId: String, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F], CS: ContextShift[F]) extends Store[F] {
+final case class BoxStore[F[_]](api: BoxAPIConnection, rootFolderId: String, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F], CS: ContextShift[F]) extends Store[F] {
 
   val rootFolder = new BoxFolder(api, rootFolderId)
 

--- a/core/src/main/scala/blobstore/Path.scala
+++ b/core/src/main/scala/blobstore/Path.scala
@@ -17,7 +17,7 @@ package blobstore
 
 import java.util.Date
 
-case class Path(root: String, key: String, size: Option[Long], isDir: Boolean, lastModified: Option[Date]) {
+final case class Path(root: String, key: String, size: Option[Long], isDir: Boolean, lastModified: Option[Date]) {
   override def toString: String = s"$root/$key"
 }
 

--- a/core/src/main/scala/blobstore/fs/FileStore.scala
+++ b/core/src/main/scala/blobstore/fs/FileStore.scala
@@ -26,7 +26,7 @@ import fs2.{Sink, Stream}
 
 import scala.concurrent.ExecutionContext
 
-case class FileStore[F[_] : ContextShift](fsroot: NioPath, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F]) extends Store[F] {
+final case class FileStore[F[_] : ContextShift](fsroot: NioPath, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F]) extends Store[F] {
   val absRoot: String = fsroot.toAbsolutePath.normalize.toString
 
   override def list(path: Path): fs2.Stream[F, Path] = {

--- a/core/src/test/scala/blobstore/StoreOpsTest.scala
+++ b/core/src/test/scala/blobstore/StoreOpsTest.scala
@@ -43,7 +43,7 @@ class StoreOpsTest extends FlatSpec with MustMatchers with TestInstances {
 
 }
 
-case class DummyStore(check: Path => Assertion) extends Store[IO] {
+final case class DummyStore(check: Path => Assertion) extends Store[IO] {
   val buf = new ArrayBuffer[Byte]()
   override def put(path: Path): Sink[IO, Byte] = {
     check(path)

--- a/s3/src/main/scala/blobstore/s3/S3Store.scala
+++ b/s3/src/main/scala/blobstore/s3/S3Store.scala
@@ -25,14 +25,14 @@ import fs2.{Chunk, Sink, Stream}
 
 import scala.collection.JavaConverters._
 import com.amazonaws.services.s3.AmazonS3
-import com.amazonaws.services.s3.model.{CopyObjectRequest, ListObjectsRequest, ObjectListing, ObjectMetadata}
+import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
 
 import scala.concurrent.ExecutionContext
 
-case class S3Store[F[_] : ConcurrentEffect : ContextShift](tm: TransferManager, sse: Option[String] = None, blockingExecutionContext: ExecutionContext)(implicit F: Effect[F]) extends Store[F] {
+final case class S3Store[F[_] : ConcurrentEffect : ContextShift](transferManager: TransferManager, sseAlgorithm: Option[String] = None, blockingExecutionContext: ExecutionContext)(implicit F: Effect[F]) extends Store[F] {
 
-  final val s3: AmazonS3 = tm.getAmazonS3Client
+  final val s3: AmazonS3 = transferManager.getAmazonS3Client
 
   private def _chunk(ol: ObjectListing): Chunk[Path] = {
     val dirs: Chunk[Path] = Chunk.seq(ol.getCommonPrefixes.asScala.map(s =>
@@ -81,8 +81,8 @@ case class S3Store[F[_] : ConcurrentEffect : ContextShift](tm: TransferManager, 
       val putToS3 = Stream.eval(F.delay {
         val meta = new ObjectMetadata()
         path.size.foreach(meta.setContentLength)
-        sse.foreach(meta.setSSEAlgorithm)
-        tm.upload(path.root, path.key, ios._2, meta).waitForCompletion()
+        sseAlgorithm.foreach(meta.setSSEAlgorithm)
+        transferManager.upload(path.root, path.key, ios._2, meta).waitForCompletion()
         ()
       })
 
@@ -107,7 +107,7 @@ case class S3Store[F[_] : ConcurrentEffect : ContextShift](tm: TransferManager, 
 
   override def copy(src: Path, dst: Path): F[Unit] = F.delay {
     val meta = new ObjectMetadata()
-    sse.foreach(meta.setSSEAlgorithm)
+    sseAlgorithm.foreach(meta.setSSEAlgorithm)
     val req = new CopyObjectRequest(src.root, src.key, dst.root, dst.key).withNewObjectMetadata(meta)
     s3.copyObject(req)
   }.void
@@ -119,13 +119,13 @@ object S3Store {
   /**
     * Safely initialize S3Store and shutdown Amazon S3 client upon finish.
     *
-    * @param fa  F[TransferManager] how to connect AWS S3 client
-    * @param sse Boolean true to force all writes to use SSE algorithm ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION
+    * @param functor  F[TransferManager] how to connect AWS S3 client
+    * @param encrypt Boolean true to force all writes to use SSE algorithm ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_] : ContextShift](fa: F[TransferManager], sse: Boolean, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F]): Stream[F, S3Store[F]] = {
-    val opt = if (sse) Option(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION) else None
-    apply(fa, opt, blockingExecutionContext)
+  def apply[F[_] : ContextShift](functor: F[TransferManager], encrypt: Boolean, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F]): Stream[F, S3Store[F]] = {
+    val opt = if (encrypt) Option(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION) else None
+    apply(functor, opt, blockingExecutionContext)
   }
 
   /**
@@ -134,11 +134,11 @@ object S3Store {
     * NOTICE: Standard S3 client builder uses the Default Credential Provider Chain, see docs on how to authenticate:
     *         https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html
     *
-    * @param sse Boolean true to force all writes to use SSE algorithm ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION
+    * @param encrypt Boolean true to force all writes to use SSE algorithm ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_] : ContextShift](sse: Boolean, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F]): Stream[F, S3Store[F]] = {
-    val opt = if (sse) Option(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION) else None
+  def apply[F[_] : ContextShift](encrypt: Boolean, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F]): Stream[F, S3Store[F]] = {
+    val opt = if (encrypt) Option(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION) else None
     apply(F.delay(TransferManagerBuilder.standard().build()), opt, blockingExecutionContext)
   }
 
@@ -148,11 +148,11 @@ object S3Store {
     * NOTICE: Standard S3 client builder uses the Default Credential Provider Chain, see docs on how to authenticate:
     *         https://docs.aws.amazon.com/sdk-for-java/v1/developer-guide/credentials.html
     *
-    * @param sse Boolean true to force all writes to use SSE algorithm ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION
+    * @param sseAlgorithm SSE algorithm, ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION is recommended.
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_] : ContextShift](sse: String, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F]): Stream[F, S3Store[F]] =
-    apply(F.delay(TransferManagerBuilder.standard().build()), Option(sse), blockingExecutionContext)
+  def apply[F[_] : ContextShift](sseAlgorithm: String, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F]): Stream[F, S3Store[F]] =
+    apply(F.delay(TransferManagerBuilder.standard().build()), Option(sseAlgorithm), blockingExecutionContext)
 
 
   /**
@@ -171,15 +171,15 @@ object S3Store {
   /**
     * Safely initialize S3Store and shutdown Amazon S3 client upon finish.
     *
-    * @param fa F[TransferManager] how to connect AWS S3 client
-    * @param sse Option[String] sse algorithm
+    * @param functor F[TransferManager] how to connect AWS S3 client
+    * @param sseAlgorithm Option[String] Server Side Encryption algorithm
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_]: ContextShift](fa: F[TransferManager], sse: Option[String], blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F])
+  def apply[F[_]: ContextShift](functor: F[TransferManager], sseAlgorithm: Option[String], blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F])
   : Stream[F, S3Store[F]] = {
-    fs2.Stream.bracket(fa)(client => F.delay(client.getAmazonS3Client.shutdown())).flatMap {
+    fs2.Stream.bracket(functor)(client => F.delay(client.getAmazonS3Client.shutdown())).flatMap {
       client => {
-        fs2.Stream.eval(F.delay(S3Store[F](client, sse, blockingExecutionContext)))
+        fs2.Stream.eval(F.delay(S3Store[F](client, sseAlgorithm, blockingExecutionContext)))
       }
     }
   }

--- a/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
+++ b/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
@@ -38,11 +38,11 @@ class S3StoreTest extends AbstractStoreTest {
     .withClientConfiguration(clientConfiguration)
     .withCredentials(new AWSStaticCredentialsProvider(credentials))
     .build()
-  private val tm: TransferManager = TransferManagerBuilder.standard()
+  private val transferManager: TransferManager = TransferManagerBuilder.standard()
     .withS3Client(client)
     .build()
 
-  override val store: Store[IO] = S3Store[IO](tm, blockingExecutionContext = blockingExecutionContext)
+  override val store: Store[IO] = S3Store[IO](transferManager, blockingExecutionContext = blockingExecutionContext)
   override val root: String = "blobstore-test-bucket"
 
   override def beforeAll(): Unit = {

--- a/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
+++ b/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
@@ -21,6 +21,7 @@ import com.amazonaws.ClientConfiguration
 import com.amazonaws.auth.{AWSStaticCredentialsProvider, BasicAWSCredentials}
 import com.amazonaws.client.builder.AwsClientBuilder
 import com.amazonaws.regions.Regions
+import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
 import com.amazonaws.services.s3.{AmazonS3, AmazonS3ClientBuilder}
 
 class S3StoreTest extends AbstractStoreTest {
@@ -28,8 +29,8 @@ class S3StoreTest extends AbstractStoreTest {
   val credentials = new BasicAWSCredentials("my_access_key", "my_secret_key")
   val clientConfiguration = new ClientConfiguration()
   clientConfiguration.setSignerOverride("AWSS3V4SignerType")
-  val minioHost = Option(System.getenv("BLOBSTORE_MINIO_HOST")).getOrElse("minio-container")
-  val minioPort = Option(System.getenv("BLOBSTORE_MINIO_PORT")).getOrElse("9000")
+  val minioHost: String = Option(System.getenv("BLOBSTORE_MINIO_HOST")).getOrElse("minio-container")
+  val minioPort: String = Option(System.getenv("BLOBSTORE_MINIO_PORT")).getOrElse("9000")
   private val client: AmazonS3 = AmazonS3ClientBuilder.standard()
     .withEndpointConfiguration(new AwsClientBuilder.EndpointConfiguration(
       s"http://$minioHost:$minioPort", Regions.US_EAST_1.name()))
@@ -37,8 +38,11 @@ class S3StoreTest extends AbstractStoreTest {
     .withClientConfiguration(clientConfiguration)
     .withCredentials(new AWSStaticCredentialsProvider(credentials))
     .build()
+  private val tm: TransferManager = TransferManagerBuilder.standard()
+    .withS3Client(client)
+    .build()
 
-  override val store: Store[IO] = S3Store[IO](client, blockingExecutionContext = blockingExecutionContext)
+  override val store: Store[IO] = S3Store[IO](tm, blockingExecutionContext = blockingExecutionContext)
   override val root: String = "blobstore-test-bucket"
 
   override def beforeAll(): Unit = {

--- a/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
+++ b/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
@@ -25,7 +25,7 @@ import scala.util.Try
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-case class SftpStore[F[_]](absRoot: String, channel: ChannelSftp, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F], CS: ContextShift[F])
+final case class SftpStore[F[_]](absRoot: String, channel: ChannelSftp, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F], CS: ContextShift[F])
   extends Store[F] {
   import implicits._
 

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.3-SNAPSHOT"
+version in ThisBuild := "0.3.0-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.2.0-SNAPSHOT"
+version in ThisBuild := "0.2.3-SNAPSHOT"


### PR DESCRIPTION
TODO: bump the version.

Relevant:

Q:     How much data can I store in Amazon S3?

The total volume of data and number of objects you can store are unlimited. Individual Amazon S3 objects can range in size from a minimum of 0 bytes to a maximum of 5 terabytes. The largest object that can be uploaded in a single PUT is 5 gigabytes. For objects larger than 100 megabytes, customers should consider using the Multipart Upload capability.

AWS guidance is use TransferManager/Mulitpart upload for anything over 100mb