### PR TITLE
Make object ACLs configurable for S3Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+v0.4.0
+======
+* Make object ACLs configurable for S3Store
+
 v0.3.1
 ======
 * Update S3Store to use other TransferManager methods when possible

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "0.3.1-SNAPSHOT"
+version in ThisBuild := "0.4.0-SNAPSHOT"


### PR DESCRIPTION
Allowing for configuration of a default object ACL, using one of the SDK's CannedAccessControlList