### PR TITLE
Make path scheme agnostic

### DIFF
--- a/core/src/main/scala/blobstore/Path.scala
+++ b/core/src/main/scala/blobstore/Path.scala
@@ -27,7 +27,7 @@ object Path {
 
   def apply(path: String): Path = {
     val x = path
-      .replaceFirst("^(s3:/)?/", "")
+      .replaceFirst("^([a-zA-Z][-.+a-zA-Z0-9]+:/)?/", "") // The regex identifies a scheme as described in https://www.ietf.org/rfc/rfc2396.txt chapter 3.1 "Scheme Component"
       .split("/", 2)
     val r = x(0)
     val k = if (x.length <= 1) "" else x(1)

--- a/core/src/test/scala/blobstore/PathTest.scala
+++ b/core/src/test/scala/blobstore/PathTest.scala
@@ -21,8 +21,10 @@ import blobstore.PathOps._
 class PathTest extends FlatSpec with MustMatchers {
   behavior of "Path"
   it should "parse string path to file correctly" in {
-    val path = Path("s3://some-bucket/path/to/file")
-    path must be(Path("some-bucket", "path/to/file", None, false, None))
+    val s3Path = Path("s3://some-bucket/path/to/file")
+    val gcsPath = Path("gcs://some-bucket/path/to/file")
+    s3Path must be(Path("some-bucket", "path/to/file", None, false, None))
+    gcsPath must be(Path("some-bucket", "path/to/file", None, false, None))
   }
 
   it should "parse string path to file without prefix correctly" in {


### PR DESCRIPTION
Treat all schemes the same in `core`, don't do special treatment for s3