### PR TITLE
Prefer least powerful type classes necessary & unify syntax 

### DIFF
--- a/core/src/main/scala/blobstore/StoreOps.scala
+++ b/core/src/main/scala/blobstore/StoreOps.scala
@@ -17,7 +17,7 @@ package blobstore
 
 import java.nio.charset.Charset
 
-import cats.effect.{ConcurrentEffect, ContextShift, Effect, Sync}
+import cats.effect.{ContextShift, Sync}
 import fs2.{Pipe, Sink, Stream}
 import cats.implicits._
 
@@ -58,7 +58,7 @@ trait StoreOps {
       * @param path Path to write to
       * @return Sink[F, Byte] buffered sink
       */
-    def bufferedPut(path: Path, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F], CS: ContextShift[F]): Sink[F, Byte] = in =>
+    def bufferedPut(path: Path, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F], CS: ContextShift[F]): Sink[F, Byte] = in =>
       in.through(bufferToDisk(4096, blockingExecutionContext)).flatMap { case (n, s) =>
         s.to(store.put(path.copy(size = Some(n))))
       }
@@ -86,7 +86,7 @@ trait StoreOps {
       * @param path Path to get
       * @return F[String] with file contents
       */
-    def getContents(path: Path)(implicit F: Effect[F]): F[String] = getContents(path, fs2.text.utf8Decode)
+    def getContents(path: Path)(implicit F: Sync[F]): F[String] = getContents(path, fs2.text.utf8Decode)
 
     /**
       * Decode get bytes from path into a string using decoder and return concatenated string.
@@ -97,7 +97,7 @@ trait StoreOps {
       * @param decoder Pipe[F, Byte, String]
       * @return F[String] with file contents
       */
-    def getContents(path: Path, decoder: Pipe[F, Byte, String])(implicit F: Effect[F]): F[String] = {
+    def getContents(path: Path, decoder: Pipe[F, Byte, String])(implicit F: Sync[F]): F[String] = {
       get(path).through(decoder).compile.toList.map(_.mkString)
     }
 

--- a/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
+++ b/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
@@ -18,14 +18,14 @@ package sftp
 
 import java.util.Date
 
-import cats.effect.{ConcurrentEffect, ContextShift}
+import cats.effect.{Concurrent, ContextShift}
 import com.jcraft.jsch._
 
 import scala.util.Try
 import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
 
-final case class SftpStore[F[_]](absRoot: String, channel: ChannelSftp, blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F], CS: ContextShift[F])
+final case class SftpStore[F[_]](absRoot: String, channel: ChannelSftp, blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F])
   extends Store[F] {
   import implicits._
 
@@ -128,7 +128,7 @@ object SftpStore {
     * @param fa F[ChannelSftp] how to connect to SFTP server
     * @return Stream[ F, SftpStore[F] ] stream with one SftpStore, sftp channel will disconnect once stream is done.
     */
-  def apply[F[_]: ContextShift](absRoot: String, fa: F[ChannelSftp], blockingExecutionContext: ExecutionContext)(implicit F: ConcurrentEffect[F])
+  def apply[F[_]](absRoot: String, fa: F[ChannelSftp], blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F])
   : fs2.Stream[F, SftpStore[F]] = {
     fs2.Stream.bracket(fa)(
       release = channel => F.delay { channel.disconnect() ; channel.getSession.disconnect() }


### PR DESCRIPTION
This PR replaces excessively powerful type classes with minimal necessary ones, mainly:
`ConcurrentEffect`, `Effect` ->  `Concurrent`, `Sync`.

Besides it unifies syntax used. It seems like implicit evidence were used more than context bounds in this project, so this PR follows that.