### PR TITLE
Concurrent SftpStore and changes from #48, #49, #50

### DIFF
--- a/core/src/main/scala/blobstore/fs/FileStore.scala
+++ b/core/src/main/scala/blobstore/fs/FileStore.scala
@@ -26,7 +26,7 @@ import fs2.{Sink, Stream}
 
 import scala.concurrent.ExecutionContext
 
-final case class FileStore[F[_] : ContextShift](fsroot: NioPath, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F]) extends Store[F] {
+final class FileStore[F[_]](fsroot: NioPath, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F], CS: ContextShift[F]) extends Store[F] {
   val absRoot: String = fsroot.toAbsolutePath.normalize.toString
 
   override def list(path: Path): fs2.Stream[F, Path] = {
@@ -85,4 +85,8 @@ final case class FileStore[F[_] : ContextShift](fsroot: NioPath, blockingExecuti
   implicit private def _toNioPath(path: Path): NioPath =
     Paths.get(absRoot, path.root, path.key)
 
+}
+
+object FileStore{
+  def apply[F[_]](fsroot: NioPath, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F], CS: ContextShift[F]): FileStore[F] = new FileStore(fsroot, blockingExecutionContext)
 }

--- a/core/src/main/scala/blobstore/package.scala
+++ b/core/src/main/scala/blobstore/package.scala
@@ -23,10 +23,11 @@ import cats.implicits._
 import scala.concurrent.ExecutionContext
 
 package object blobstore {
-  protected[blobstore] def _writeAllToOutputStream1[F[_]](in: Stream[F, Byte], out: OutputStream)(implicit F: Sync[F]): Pull[F, Nothing, Unit] = {
+  protected[blobstore] def _writeAllToOutputStream1[F[_]](in: Stream[F, Byte], out: OutputStream, blockingExecutionContext: ExecutionContext)(
+    implicit F: Sync[F], CS: ContextShift[F]): Pull[F, Nothing, Unit] = {
     in.pull.uncons.flatMap {
       case None => Pull.done
-      case Some((hd, tl)) => Pull.eval[F, Unit](F.delay(out.write(hd.toArray))) >> _writeAllToOutputStream1(tl, out)
+      case Some((hd, tl)) => Pull.eval[F, Unit](CS.evalOn(blockingExecutionContext)(F.delay(out.write(hd.toArray)))) >> _writeAllToOutputStream1(tl, out, blockingExecutionContext)
     }
   }
 

--- a/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
+++ b/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
@@ -42,7 +42,7 @@ class S3StoreTest extends AbstractStoreTest {
     .withS3Client(client)
     .build()
 
-  override val store: Store[IO] = S3Store[IO](transferManager, blockingExecutionContext = blockingExecutionContext)
+  override val store: Store[IO] = new S3Store[IO](transferManager, blockingExecutionContext = blockingExecutionContext)
   override val root: String = "blobstore-test-bucket"
 
   override def beforeAll(): Unit = {

--- a/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
+++ b/sftp/src/main/scala/blobstore/sftp/SftpStore.scala
@@ -18,107 +18,133 @@ package sftp
 
 import java.util.Date
 
-import cats.effect.{Concurrent, ContextShift}
 import com.jcraft.jsch._
+import fs2.concurrent.Queue
 
 import scala.util.Try
-import scala.collection.JavaConverters._
 import scala.concurrent.ExecutionContext
+import java.io.OutputStream
 
-final case class SftpStore[F[_]](absRoot: String, channel: ChannelSftp, blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F])
-  extends Store[F] {
+import cats.effect.{ConcurrentEffect, ContextShift, Resource, IO}
+
+final class SftpStore[F[_]](
+  absRoot: String,
+  session: Session,
+  blockingExecutionContext: ExecutionContext,
+  pool: Queue[F, ChannelSftp],
+  connectTimeout: Int
+)(implicit F: ConcurrentEffect[F], CS: ContextShift[F]) extends Store[F] {
   import implicits._
 
   import Path.SEP
 
+  private def openChannel: F[ChannelSftp] = CS.evalOn(blockingExecutionContext)(F.delay{
+    val ch = session.openChannel("sftp").asInstanceOf[ChannelSftp]
+    ch.connect(connectTimeout)
+    ch
+  })
+
+  private def closeChannel(ch: ChannelSftp): F[Unit] =
+    CS.evalOn(blockingExecutionContext)(F.delay(ch.disconnect()))
+
+  private def channelResource: Resource[F, ChannelSftp] = Resource.make{
+    F.flatMap(pool.tryDequeue1) {
+      case Some(channel) => F.pure(channel)
+      case None => openChannel
+    }
+  }{
+    case ch if ch.isClosed => F.unit
+    case ch => F.ifM(pool.offer1(ch))(F.unit, closeChannel(ch))
+  }
+
   /**
-    * TODO: This is an unsafe list method since it uses ChannelSftp.ls(String) which loads the entire result in memory.
-    *       A better approach would be to use ChannelSftp.ls(String, LsEntrySelector) and provide a function that is
-    *       called with every LSEntry returned, this is how ChannelSftp.ls is defined:
-    *
-    *         public java.util.Vector ls(String path) throws SftpException{
-    *           final java.util.Vector v = new Vector();
-    *           LsEntrySelector selector = new LsEntrySelector(){
-    *             public int select(LsEntry entry){
-    *               v.addElement(entry);
-    *               return CONTINUE;
-    *             }
-    *           };
-    *           ls(path, selector);
-    *           return v;
-    *         }
-    *
     * @param path path to list
     * @return Stream[F, Path]
     */
   override def list(path: Path): fs2.Stream[F, Path] = {
-    val l: F[Seq[Path]] = F.delay {
-      Try(channel.ls(path).asScala.toList).getOrElse(List.empty)
-        .map(_.asInstanceOf[ChannelSftp#LsEntry])
-        .filterNot(e => e.getFilename == "." || e.getFilename == "..")
-        .map { entry =>
-          val newPath = if (path.filename == entry.getFilename) path else path / entry.getFilename
-          newPath.copy(
-            size = Option(entry.getAttrs.getSize),
-            isDir = entry.getAttrs.isDir,
-            lastModified = Option(entry.getAttrs.getMTime).map(i => new Date(i.toLong * 1000))
-          )
-        }
-    }
-    fs2.Stream.eval(l).flatMap(x => fs2.Stream.emits(x))
-  }
 
-  override def get(path: Path, chunkSize: Int): fs2.Stream[F, Byte] = {
-    fs2.io.readInputStream(F.delay(channel.get(path)), chunkSize = chunkSize, closeAfterUse = true, blockingExecutionContext = blockingExecutionContext)
+    def entrySelector(cb: ChannelSftp#LsEntry => Unit): ChannelSftp.LsEntrySelector = new ChannelSftp.LsEntrySelector{
+      def select(entry: ChannelSftp#LsEntry): Int = {
+        cb(entry)
+        ChannelSftp.LsEntrySelector.CONTINUE
+      }
+    }
+
+  for{
+    q <- fs2.Stream.eval(Queue.bounded[F, Option[ChannelSftp#LsEntry]](64))
+    channel <- fs2.Stream.resource(channelResource)
+    _ <- fs2.Stream.eval(
+      CS.evalOn(blockingExecutionContext)(F.flatMap(F.attempt(F.delay(channel.ls(path, entrySelector(e => F.runAsync(q.enqueue1(Some(e)))(_ => IO.unit).unsafeRunSync())))))(_ => q.enqueue1(None)))
+    )
+    entry <- q.dequeue.unNoneTerminate.filter(e => e.getFilename != "." && e.getFilename != "..")
+  } yield {
+    val newPath = if (path.filename == entry.getFilename) path else path / entry.getFilename
+    newPath.copy(
+      size = Option(entry.getAttrs.getSize),
+      isDir = entry.getAttrs.isDir,
+      lastModified = Option(entry.getAttrs.getMTime).map(i => new Date(i.toLong * 1000))
+    )
   }
+}
+
+  override def get(path: Path, chunkSize: Int): fs2.Stream[F, Byte] =
+    fs2.Stream.resource(channelResource).flatMap{channel =>
+      fs2.io.readInputStream(CS.evalOn(blockingExecutionContext)(F.delay(channel.get(path))), chunkSize = chunkSize, closeAfterUse = true, blockingExecutionContext = blockingExecutionContext)
+    }
 
   override def put(path: Path): fs2.Sink[F, Byte] = { in =>
-    val put = F.delay {
-      mkdirs(path)
+    def put(channel: ChannelSftp) = F.flatMap(mkdirs(path, channel))(_ => CS.evalOn(blockingExecutionContext)(F.delay {
       // scalastyle:off
       channel.put(/* dst */ path, /* monitor */ null, /* mode */ ChannelSftp.OVERWRITE, /* offset */ 0)
       // scalastyle:on
-    }
+    }))
+    
+    def close(os: OutputStream): F[Unit] = CS.evalOn(blockingExecutionContext)(F.delay(os.close()))
 
-    val pull = for {
-      os <- fs2.Pull.acquireCancellable(put)(ch => F.delay(ch.close()))
-      _ <- _writeAllToOutputStream1(in, os.resource)
+    def pull(channel: ChannelSftp) = for {
+      os <- fs2.Pull.acquireCancellable(put(channel))(ch => close(ch))
+      _ <- _writeAllToOutputStream1(in, os.resource, blockingExecutionContext)
     } yield ()
 
-    pull.stream
+    fs2.Stream.resource(channelResource).flatMap(channel => pull(channel).stream)
   }
 
-  override def move(src: Path, dst: Path): F[Unit] = F.delay {
-    mkdirs(dst)
-    channel.rename(src, dst)
-  }
+  override def move(src: Path, dst: Path): F[Unit] =
+    channelResource.use{channel =>
+      F.flatMap(mkdirs(dst, channel))(_ => CS.evalOn(blockingExecutionContext)(F.delay(channel.rename(src, dst))))
+    }
 
   override def copy(src: Path, dst: Path): F[Unit] = {
     val s = for {
-      _ <- fs2.Stream.eval(F.delay(mkdirs(dst)))
+      channel <- fs2.Stream.resource(channelResource)
+      _ <- fs2.Stream.eval(F.delay(mkdirs(dst, channel)))
       _ <- get(src).to(this.bufferedPut(dst, blockingExecutionContext))
     } yield ()
 
     s.compile.drain
   }
 
-  override def remove(path: Path): F[Unit] = F.delay({
-    try {
-      channel.rm(path)
-    } catch {
-      // Let the remove() call succeed if there is no file at this path
-      case e: SftpException if e.id == ChannelSftp.SSH_FX_NO_SUCH_FILE => ()
-    }
-  })
+  override def remove(path: Path): F[Unit] = channelResource.use{channel =>
+    CS.evalOn(blockingExecutionContext)(F.delay{
+      try {
+        channel.rm(path)
+      } catch {
+        // Let the remove() call succeed if there is no file at this path
+        case e: SftpException if e.id == ChannelSftp.SSH_FX_NO_SUCH_FILE => ()
+      }
+    })
+  }
 
   implicit def _pathToString(path: Path): String = s"$absRoot$SEP${path.root}$SEP${path.key}"
 
-  private def mkdirs(path: Path): Unit = {
-    _pathToString(path).split(SEP.toChar).drop(1).foldLeft("") { case (acc, s) =>
-      Try(channel.mkdir(acc))
-      s"$acc$SEP$s"
+  private def mkdirs(path: Path, channel: ChannelSftp): F[Unit] = CS.evalOn(blockingExecutionContext) {
+    F.delay {
+      _pathToString(path).split(SEP.toChar).drop(1).foldLeft("") { case (acc, s) =>
+        Try(channel.mkdir(acc))
+        s"$acc$SEP$s"
+      }
+      ()
     }
-    ()
   }
 }
 
@@ -128,12 +154,15 @@ object SftpStore {
     * @param fa F[ChannelSftp] how to connect to SFTP server
     * @return Stream[ F, SftpStore[F] ] stream with one SftpStore, sftp channel will disconnect once stream is done.
     */
-  def apply[F[_]](absRoot: String, fa: F[ChannelSftp], blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F])
-  : fs2.Stream[F, SftpStore[F]] = {
-    fs2.Stream.bracket(fa)(
-      release = channel => F.delay { channel.disconnect() ; channel.getSession.disconnect() }
-    ).flatMap { channel =>
-      fs2.Stream.eval(F.delay(SftpStore[F](absRoot, channel, blockingExecutionContext)))
-    }
-  }
+  def apply[F[_]](
+    absRoot: String,
+    fa: F[Session],
+    blockingExecutionContext: ExecutionContext,
+    maxChannels: Int = 10,
+    connectTimeout: Int = 10000
+  )(implicit F: ConcurrentEffect[F], CS: ContextShift[F]): fs2.Stream[F, SftpStore[F]] =
+    for {
+      session <- fs2.Stream.bracket(fa)(session => F.delay(session.disconnect()))
+      pool <- fs2.Stream.eval(Queue.bounded[F, ChannelSftp](maxChannels))
+    } yield new SftpStore[F](absRoot, session, blockingExecutionContext, pool, connectTimeout)
 }

--- a/sftp/src/test/scala/blobstore/sftp/SftpStoreTest.scala
+++ b/sftp/src/test/scala/blobstore/sftp/SftpStoreTest.scala
@@ -21,10 +21,11 @@ import java.util.Properties
 
 import cats.effect.IO
 import com.jcraft.jsch.{ChannelSftp, JSch}
+import fs2.concurrent.Queue
 
 class SftpStoreTest extends AbstractStoreTest {
 
-  val (channel, session) = try {
+  val session = try {
     val jsch = new JSch()
 
     val session = jsch.getSession("blob", "sftp-container", 22)
@@ -37,18 +38,17 @@ class SftpStoreTest extends AbstractStoreTest {
 
     session.connect()
 
-    val channel = session.openChannel("sftp").asInstanceOf[ChannelSftp]
-    channel.connect(10000)
-    (channel, session)
+    session
   } catch {
     // this is UGLY!!! but just want to ignore errors if you don't have sftp container running
     case e: Throwable =>
       e.printStackTrace()
-      (null, null)
+      null
   }
 
   private val rootDir = Paths.get("tmp/sftp-store-root/").toAbsolutePath.normalize
-  override val store: Store[IO] = SftpStore[IO]("/", channel, blockingExecutionContext = blockingExecutionContext)
+  val queue = Queue.bounded[IO, ChannelSftp](1).unsafeRunSync()
+  override val store: Store[IO] = new SftpStore[IO]("/", session, blockingExecutionContext, queue, 10000)
   override val root: String = "sftp_tests"
 
   // remove dirs created by AbstractStoreTest
@@ -56,7 +56,6 @@ class SftpStoreTest extends AbstractStoreTest {
     super.afterAll()
 
     try {
-      channel.disconnect()
       session.disconnect()
     } catch {
       case _: Throwable =>

--- a/sftp/src/test/scala/blobstore/sftp/SftpStoreTest.scala
+++ b/sftp/src/test/scala/blobstore/sftp/SftpStoreTest.scala
@@ -20,8 +20,8 @@ import java.nio.file.Paths
 import java.util.Properties
 
 import cats.effect.IO
+import cats.effect.concurrent.MVar
 import com.jcraft.jsch.{ChannelSftp, JSch}
-import fs2.concurrent.Queue
 
 class SftpStoreTest extends AbstractStoreTest {
 
@@ -47,8 +47,8 @@ class SftpStoreTest extends AbstractStoreTest {
   }
 
   private val rootDir = Paths.get("tmp/sftp-store-root/").toAbsolutePath.normalize
-  val queue = Queue.bounded[IO, ChannelSftp](1).unsafeRunSync()
-  override val store: Store[IO] = new SftpStore[IO]("/", session, blockingExecutionContext, queue, 10000)
+  val mVar = MVar.empty[IO, ChannelSftp].unsafeRunSync()
+  override val store: Store[IO] = new SftpStore[IO]("/", session, blockingExecutionContext, mVar, None, 10000)
   override val root: String = "sftp_tests"
 
   // remove dirs created by AbstractStoreTest


### PR DESCRIPTION
This PR fixes #51
Please note that it also includes changes introduced in #48, #49 and #50

Also in this PR all the store classes have been changed from being case classes to regular classes. This is an opinionated change, so could be reversed. Main motivation for doing that is to make constructor parameters inaccessible from outside.