### PR TITLE
Scala 2.13.0 + Updated dependencies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,8 @@ services:
 
 scala:
 - 2.11.12
-- 2.12.6
+- 2.12.10
+- 2.13.0
 
 jdk:
 - openjdk8

--- a/box/build.sbt
+++ b/box/build.sbt
@@ -1,5 +1,5 @@
 name := "box"
 
 libraryDependencies ++= Seq(
-  "com.box" % "box-java-sdk" % "2.16.0"
+  "com.box" % "box-java-sdk" % "2.41.0"
 )

--- a/box/src/main/scala/blobstore/box/BoxStore.scala
+++ b/box/src/main/scala/blobstore/box/BoxStore.scala
@@ -19,14 +19,13 @@ package box
 import java.io.{InputStream, OutputStream, PipedInputStream, PipedOutputStream}
 
 import cats.implicits._
-import cats.effect.{Concurrent, ContextShift}
+import cats.effect.{Blocker, Concurrent, ContextShift}
 import com.box.sdk.{BoxAPIConnection, BoxFile, BoxFolder, BoxItem}
-import fs2.{Sink, Stream}
+import fs2.{Pipe, Stream}
 
-import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
 
-final class BoxStore[F[_]](api: BoxAPIConnection, rootFolderId: String, blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F]) extends Store[F] {
+final class BoxStore[F[_]](api: BoxAPIConnection, rootFolderId: String, blocker: Blocker)(implicit F: Concurrent[F], CS: ContextShift[F]) extends Store[F] {
 
   val rootFolder = new BoxFolder(api, rootFolderId)
 
@@ -111,7 +110,7 @@ final class BoxStore[F[_]](api: BoxAPIConnection, rootFolderId: String, blocking
           bothStreams._1.close()
         }))).getOrElse(Stream.fromIterator(Iterator.empty))
 
-        readInput = fs2.io.readInputStream(F.delay(bothStreams._2), chunkSize, closeAfterUse = true, blockingExecutionContext = blockingExecutionContext)
+        readInput = fs2.io.readInputStream(F.delay(bothStreams._2), chunkSize, closeAfterUse = true, blocker = blocker)
 
         s <- readInput concurrently dl
     } yield s
@@ -169,7 +168,7 @@ final class BoxStore[F[_]](api: BoxAPIConnection, rootFolderId: String, blocking
     * @param path to put
     * @return sink of bytes. This throws an exception if a file at this path already exists.
     */
-  override def put(path: Path): Sink[F, Byte] = { in =>
+  override def put(path: Path): Pipe[F, Byte, Unit] = { in =>
     val pathSplit = splitPath(path)
 
     val init: F[(OutputStream, InputStream, BoxFolder)] = F.delay {
@@ -181,7 +180,7 @@ final class BoxStore[F[_]](api: BoxAPIConnection, rootFolderId: String, blocking
 
     val consume: ((OutputStream, InputStream, BoxFolder)) => Stream[F, Unit] = ios => {
       val putToBox = Stream.eval(F.delay(ios._3.uploadFile(ios._2, pathSplit._2)).void)
-      val writeBytes = _writeAllToOutputStream1(in, ios._1, blockingExecutionContext).stream ++ Stream.eval(F.delay(ios._1.close()))
+      val writeBytes = _writeAllToOutputStream1(in, ios._1, blocker).stream ++ Stream.eval(F.delay(ios._1.close()))
       putToBox concurrently writeBytes
     }
 
@@ -240,6 +239,6 @@ object BoxStore{
   def apply[F[_]](
     api: BoxAPIConnection,
     rootFolderId: String,
-    blockingExecutionContext: ExecutionContext
-  )(implicit F: Concurrent[F], CS: ContextShift[F]): BoxStore[F] = new BoxStore(api, rootFolderId, blockingExecutionContext)
+    blocker: Blocker
+  )(implicit F: Concurrent[F], CS: ContextShift[F]): BoxStore[F] = new BoxStore(api, rootFolderId, blocker)
 }

--- a/box/src/test/scala/blobstore/box/BoxStoreIntegrationTest.scala
+++ b/box/src/test/scala/blobstore/box/BoxStoreIntegrationTest.scala
@@ -23,7 +23,7 @@ class BoxStoreIntegrationTest extends AbstractStoreTest {
   // This test simply uses a dev token to start a connection, but you can replace this with any BoxAPIConnection.
   val api = new BoxAPIConnection(boxDevToken)
 
-  override val store: Store[IO] = new BoxStore[IO](api, rootFolderId, blockingExecutionContext)
+  override val store: Store[IO] = new BoxStore[IO](api, rootFolderId, blocker)
 
   // If your rootFolderId is a safe directory to test under, this root string doesn't matter that much.
   override val root: String = "BoxStoreTest"

--- a/build.sbt
+++ b/build.sbt
@@ -1,8 +1,8 @@
 name := "fs2-blobstore"
 
 inThisBuild(Seq(
-  scalaVersion := "2.12.7",
-  crossScalaVersions := Seq("2.11.12", "2.12.7"),
+  scalaVersion := "2.12.10",
+  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.0"),
   organization := "com.lendup.fs2-blobstore"
 ))
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,12 +1,15 @@
 name := "core"
 
-val fs2Version = "1.0.0"
+val fs2Version = "2.0.1"
 
 libraryDependencies ++= Seq(
   "co.fs2" %% "fs2-core" % fs2Version,
   "co.fs2" %% "fs2-io" % fs2Version,
-  "org.scalatest" %% "scalatest" % "3.0.4" % "test",
-  "org.typelevel" %% "cats-effect-laws" % "1.0.0" % "test"
-)
-
-scalacOptions += "-Ypartial-unification"
+  "org.scalatest" %% "scalatest" % "3.2.0-M1" % "test",
+  "org.typelevel" %% "cats-effect-laws" % "2.0.0" % "test"
+) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
+  case Some((2, x)) if x < 13 =>
+    "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2" :: Nil
+  case _ =>
+    Nil
+})

--- a/core/src/main/scala/blobstore/Store.scala
+++ b/core/src/main/scala/blobstore/Store.scala
@@ -15,7 +15,7 @@ Copyright 2018 LendUp Global, Inc.
 */
 package blobstore
 
-import fs2.{Sink, Stream}
+import fs2.{Pipe, Stream}
 
 trait Store[F[_]] {
 
@@ -46,7 +46,7 @@ trait Store[F[_]] {
     * @param path to put
     * @return sink of bytes
     */
-  def put(path: Path): Sink[F, Byte]
+  def put(path: Path): Pipe[F, Byte, Unit]
 
   /**
     * Moves bytes from srcPath to dstPath. Stores should optimize to use native move functions to avoid data transfer.

--- a/core/src/main/scala/blobstore/fs/FileStore.scala
+++ b/core/src/main/scala/blobstore/fs/FileStore.scala
@@ -19,14 +19,12 @@ package fs
 import java.nio.file.{Files, Paths, Path => NioPath}
 import java.util.Date
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import cats.implicits._
-import cats.effect.{ContextShift, Sync}
-import fs2.{Sink, Stream}
+import cats.effect.{Blocker, ContextShift, Sync}
+import fs2.{Pipe, Stream}
 
-import scala.concurrent.ExecutionContext
-
-final class FileStore[F[_]](fsroot: NioPath, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F], CS: ContextShift[F]) extends Store[F] {
+final class FileStore[F[_]](fsroot: NioPath, blocker: Blocker)(implicit F: Sync[F], CS: ContextShift[F]) extends Store[F] {
   val absRoot: String = fsroot.toAbsolutePath.normalize.toString
 
   override def list(path: Path): fs2.Stream[F, Path] = {
@@ -55,12 +53,12 @@ final class FileStore[F[_]](fsroot: NioPath, blockingExecutionContext: Execution
     isDir.ifM(files, isFile.ifM(file, Stream.empty.covaryAll[F, Path]))
   }
 
-  override def get(path: Path, chunkSize: Int): fs2.Stream[F, Byte] = fs2.io.file.readAll[F](path, blockingExecutionContext, chunkSize)
+  override def get(path: Path, chunkSize: Int): fs2.Stream[F, Byte] = fs2.io.file.readAll[F](path, blocker, chunkSize)
 
-  override def put(path: Path): Sink[F, Byte] = { in =>
+  override def put(path: Path): Pipe[F, Byte, Unit] = { in =>
     val mkdir = Stream.eval(F.delay(Files.createDirectories(_toNioPath(path).getParent)).as(true))
     mkdir.ifM(
-      fs2.io.file.writeAll(path, blockingExecutionContext).apply(in),
+      fs2.io.file.writeAll(path, blocker).apply(in),
       Stream.raiseError[F](new Exception(s"failed to create dir: $path"))
     )
   }
@@ -88,5 +86,5 @@ final class FileStore[F[_]](fsroot: NioPath, blockingExecutionContext: Execution
 }
 
 object FileStore{
-  def apply[F[_]](fsroot: NioPath, blockingExecutionContext: ExecutionContext)(implicit F: Sync[F], CS: ContextShift[F]): FileStore[F] = new FileStore(fsroot, blockingExecutionContext)
+  def apply[F[_]](fsroot: NioPath, blocker: Blocker)(implicit F: Sync[F], CS: ContextShift[F]): FileStore[F] = new FileStore(fsroot, blocker)
 }

--- a/core/src/test/scala/blobstore/PathTest.scala
+++ b/core/src/test/scala/blobstore/PathTest.scala
@@ -15,10 +15,11 @@ Copyright 2018 LendUp Global, Inc.
 */
 package blobstore
 
-import org.scalatest.{FlatSpec, MustMatchers}
+import org.scalatest.matchers.must.Matchers
+import org.scalatest.flatspec.AnyFlatSpec
 import blobstore.PathOps._
 
-class PathTest extends FlatSpec with MustMatchers {
+class PathTest extends AnyFlatSpec with Matchers {
   behavior of "Path"
   it should "parse string path to file correctly" in {
     val s3Path = Path("s3://some-bucket/path/to/file")

--- a/core/src/test/scala/blobstore/StoreOpsTest.scala
+++ b/core/src/test/scala/blobstore/StoreOpsTest.scala
@@ -2,28 +2,32 @@ package blobstore
 
 import java.nio.charset.Charset
 import java.nio.file.Files
+import java.util.concurrent.Executors
 
-import cats.effect.IO
+import cats.effect.{Blocker, IO}
 import cats.effect.laws.util.TestInstances
 import cats.implicits._
-import fs2.Sink
-import org.scalatest.{Assertion, FlatSpec, MustMatchers}
+import fs2.Pipe
+import org.scalatest.Assertion
+import org.scalatest.flatspec.AnyFlatSpec
 import implicits._
+import org.scalatest.matchers.must.Matchers
 
 import scala.collection.mutable.ArrayBuffer
 import scala.concurrent.ExecutionContext
 
-class StoreOpsTest extends FlatSpec with MustMatchers with TestInstances {
 
-  implicit val ec = ExecutionContext.global
-  implicit val cs = IO.contextShift(ec)
+class StoreOpsTest extends AnyFlatSpec with Matchers with TestInstances {
+
+  implicit val cs = IO.contextShift(ExecutionContext.global)
+  val blocker = Blocker.liftExecutionContext(ExecutionContext.fromExecutor(Executors.newCachedThreadPool))
 
   behavior of "PutOps"
   it should "buffer contents and compute size before calling Store.put" in {
     val bytes: Array[Byte] = "AAAAAAAAAA".getBytes(Charset.forName("utf-8"))
     val store = DummyStore(_.size must be(Some(bytes.length)))
 
-    fs2.Stream.emits(bytes).covary[IO].to(store.bufferedPut(Path("path/to/file.txt"), ec)).compile.drain.unsafeRunSync()
+    fs2.Stream.emits(bytes).covary[IO].through(store.bufferedPut(Path("path/to/file.txt"), blocker)).compile.drain.unsafeRunSync()
     store.buf.toArray must be(bytes)
 
   }
@@ -35,8 +39,8 @@ class StoreOpsTest extends FlatSpec with MustMatchers with TestInstances {
     fs2.Stream.bracket(IO(Files.createTempFile("test-file", ".bin"))) { p =>
       IO(p.toFile.delete).void
     }.flatMap { p =>
-      fs2.Stream.emits(bytes).covary[IO].to(fs2.io.file.writeAll(p, ec)).drain ++
-        fs2.Stream.eval(store.put(p, Path("path/to/file.txt"), ec))
+      fs2.Stream.emits(bytes).covary[IO].through(fs2.io.file.writeAll(p, blocker)).drain ++
+        fs2.Stream.eval(store.put(p, Path("path/to/file.txt"), blocker))
     }.compile.drain.unsafeRunSync()
     store.buf.toArray must be(bytes)
   }
@@ -45,7 +49,7 @@ class StoreOpsTest extends FlatSpec with MustMatchers with TestInstances {
 
 final case class DummyStore(check: Path => Assertion) extends Store[IO] {
   val buf = new ArrayBuffer[Byte]()
-  override def put(path: Path): Sink[IO, Byte] = {
+  override def put(path: Path): Pipe[IO, Byte, Unit] = {
     check(path)
     in => {
       buf.appendAll(in.compile.toVector.unsafeRunSync())

--- a/core/src/test/scala/blobstore/fs/FileStoreTest.scala
+++ b/core/src/test/scala/blobstore/fs/FileStoreTest.scala
@@ -22,7 +22,7 @@ import cats.effect.IO
 class FileStoreTest extends AbstractStoreTest {
 
   val rootDir: NioPath = Paths.get("tmp/file-store-root/")
-  override val store: Store[IO] = FileStore[IO](rootDir, blockingExecutionContext)
+  override val store: Store[IO] = FileStore[IO](rootDir, blocker)
   override val root: String = "file_tests"
 
   behavior of "FileStore.put"

--- a/gcs/build.sbt
+++ b/gcs/build.sbt
@@ -1,6 +1,6 @@
 name := "gcs"
 
 libraryDependencies ++= Seq(
-  "com.google.cloud" % "google-cloud-storage" % "1.87.0",
-  "com.google.cloud" % "google-cloud-nio" % "0.105.0-alpha" % Test
+  "com.google.cloud" % "google-cloud-storage" % "1.98.0",
+  "com.google.cloud" % "google-cloud-nio" % "0.116.0-alpha" % Test
 )

--- a/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
+++ b/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
@@ -5,16 +5,15 @@ import java.time.Instant
 import java.util.Date
 
 import blobstore.{Path, Store}
-import cats.effect.{ContextShift, Sync}
+import cats.effect.{Blocker, ContextShift, Sync}
 import com.google.api.gax.paging.Page
 import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, Storage}
 import com.google.cloud.storage.Storage.{BlobListOption, CopyRequest}
-import fs2.{Chunk, Sink, Stream}
+import fs2.{Chunk, Pipe, Stream}
 
-import scala.collection.JavaConverters._
-import scala.concurrent.ExecutionContext
+import scala.jdk.CollectionConverters._
 
-final class GcsStore[F[_]](storage: Storage, blockingExecutionContext: ExecutionContext, acls: List[Acl] = Nil)(implicit F: Sync[F], CS: ContextShift[F]) extends Store[F] {
+final class GcsStore[F[_]](storage: Storage, blocker: Blocker, acls: List[Acl] = Nil)(implicit F: Sync[F], CS: ContextShift[F]) extends Store[F] {
 
   private def _chunk(pg: Page[Blob]): Chunk[Path] = {
     val (dirs, files) = pg.getValues.asScala.toSeq.partition(_.isDirectory)
@@ -31,7 +30,7 @@ final class GcsStore[F[_]](storage: Storage, blockingExecutionContext: Execution
     Stream.unfoldChunkEval[F, () => Option[Page[Blob]], Path]{
       () => Some(storage.list(path.root, BlobListOption.currentDirectory(), BlobListOption.prefix(path.key)))
     }{getPage =>
-      CS.evalOn(blockingExecutionContext)(F.delay{
+      blocker.delay{
         getPage().map{pg =>
           if (pg.hasNextPage){
             (_chunk(pg), () => Some(pg.getNextPage))
@@ -39,16 +38,16 @@ final class GcsStore[F[_]](storage: Storage, blockingExecutionContext: Execution
             (_chunk(pg), () => None)
           }
         }
-      })
+      }
     }
   }
 
   def get(path: Path, chunkSize: Int): fs2.Stream[F, Byte] = {
-    val is = CS.evalOn(blockingExecutionContext)(F.delay(Channels.newInputStream(storage.get(path.root, path.key).reader())))
-    fs2.io.readInputStream(is, chunkSize, blockingExecutionContext, closeAfterUse = true)
+    val is = blocker.delay(Channels.newInputStream(storage.get(path.root, path.key).reader()))
+    fs2.io.readInputStream(is, chunkSize, blocker, closeAfterUse = true)
   }
 
-  def put(path: Path): Sink[F, Byte] = {
+  def put(path: Path): Pipe[F, Byte, Unit] = {
     val fos = Sync[F].delay{
       val builder = {
         val b = BlobInfo.newBuilder(path.root, path.key)
@@ -58,25 +57,25 @@ final class GcsStore[F[_]](storage: Storage, blockingExecutionContext: Execution
       val writer = storage.writer(blobInfo)
       Channels.newOutputStream(writer)
     }
-    fs2.io.writeOutputStream(fos, blockingExecutionContext, closeAfterUse = true)
+    fs2.io.writeOutputStream(fos, blocker, closeAfterUse = true)
   }
 
   def move(src: Path, dst: Path): F[Unit] = F.productR(copy(src, dst))(remove(src))
 
   def copy(src: Path, dst: Path): F[Unit] = {
     val req = CopyRequest.newBuilder().setSource(src.root, src.key).setTarget(BlobId.of(dst.root, dst.key)).build()
-    CS.evalOn(blockingExecutionContext)(F.map(F.delay(storage.copy(req).getResult))(_ => ()))
+    F.void(blocker.delay(storage.copy(req).getResult))
   }
 
   def remove(path: Path): F[Unit] =
-    CS.evalOn(blockingExecutionContext)(F.map(F.delay(storage.delete(path.root, path.key)))(_ => ()))
+    F.void(blocker.delay(storage.delete(path.root, path.key)))
 }
 
 
 object GcsStore{
   def apply[F[_]](
     storage: Storage,
-    blockingExecutionContext: ExecutionContext,
+    blocker: Blocker,
     acls: List[Acl]
-  )(implicit F: Sync[F], CS: ContextShift[F]): GcsStore[F] = new GcsStore(storage, blockingExecutionContext, acls)
+  )(implicit F: Sync[F], CS: ContextShift[F]): GcsStore[F] = new GcsStore(storage, blocker, acls)
 }

--- a/gcs/src/test/scala/blobstore/gcs/GcsStoreTest.scala
+++ b/gcs/src/test/scala/blobstore/gcs/GcsStoreTest.scala
@@ -5,6 +5,6 @@ import cats.effect.IO
 import com.google.cloud.storage.contrib.nio.testing.LocalStorageHelper
 
 class GcsStoreTest extends AbstractStoreTest {
-  override val store: Store[IO] = new GcsStore[IO](LocalStorageHelper.getOptions.getService, blockingExecutionContext)
+  override val store: Store[IO] = new GcsStore[IO](LocalStorageHelper.getOptions.getService, blocker)
   override val root: String = "bucket"
 }

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.1.0
+sbt.version=1.3.3

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,5 @@
 addSbtPlugin("io.verizon.build" % "sbt-rig" % "5.0.39")
-addSbtPlugin("io.get-coursier" % "sbt-coursier" % "1.0.1")
+addSbtPlugin("org.lyranthe.sbt" % "partial-unification" % "1.1.2")
+addSbtPlugin("org.scoverage" % "sbt-scoverage" % "1.6.0")
 addSbtPlugin("org.scalastyle" %% "scalastyle-sbt-plugin" % "1.0.0")
-
+addSbtPlugin("io.github.davidgregory084" % "sbt-tpolecat" % "0.1.8")

--- a/s3/build.sbt
+++ b/s3/build.sbt
@@ -1,5 +1,5 @@
 name := "s3"
 
 libraryDependencies ++= Seq(
-  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.283"
+  "com.amazonaws" % "aws-java-sdk-s3" % "1.11.659"
 )

--- a/s3/src/main/scala/blobstore/s3/S3Store.scala
+++ b/s3/src/main/scala/blobstore/s3/S3Store.scala
@@ -18,19 +18,17 @@ package s3
 
 import java.io.{InputStream, PipedInputStream, PipedOutputStream}
 
-import cats.effect.{Concurrent, ContextShift}
+import cats.effect.{Blocker, Concurrent, ContextShift}
 import cats.syntax.functor._
 import cats.syntax.flatMap._
-import fs2.{Chunk, Sink, Stream}
+import fs2.{Chunk, Pipe, Stream}
 
-import scala.collection.JavaConverters._
+import scala.jdk.CollectionConverters._
 import com.amazonaws.services.s3.AmazonS3
 import com.amazonaws.services.s3.model._
 import com.amazonaws.services.s3.transfer.{TransferManager, TransferManagerBuilder}
 
-import scala.concurrent.ExecutionContext
-
-final class S3Store[F[_]](transferManager: TransferManager, objectAcl: Option[CannedAccessControlList] = None, sseAlgorithm: Option[String] = None, blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F]) extends Store[F] {
+final class S3Store[F[_]](transferManager: TransferManager, objectAcl: Option[CannedAccessControlList] = None, sseAlgorithm: Option[String] = None, blocker: Blocker)(implicit F: Concurrent[F], CS: ContextShift[F]) extends Store[F] {
 
   val s3: AmazonS3 = transferManager.getAmazonS3Client
 
@@ -54,23 +52,23 @@ final class S3Store[F[_]](transferManager: TransferManager, objectAcl: Option[Ca
       // to unfold the stream we need to emit a Chunk for the current ObjectListing received from state function
       // if returned ObjectListing is not truncated we emit the last Chunk and set up state function to return None
       // and stop unfolding in the next iteration
-      getObjectListing => CS.evalOn(blockingExecutionContext)(F.delay{
+      getObjectListing => blocker.delay{
         getObjectListing().map { ol =>
           if (ol.isTruncated)
             (_chunk(ol), () => Option(s3.listNextBatchOfObjects(ol)))
           else
             (_chunk(ol), () => None)
         }
-      })
+      }
     }
   }
 
   override def get(path: Path, chunkSize: Int): Stream[F, Byte] = {
-    val is: F[InputStream] = CS.evalOn(blockingExecutionContext)(F.delay(s3.getObject(path.root, path.key).getObjectContent))
-    fs2.io.readInputStream(is, chunkSize, closeAfterUse = true, blockingExecutionContext = blockingExecutionContext)
+    val is: F[InputStream] = blocker.delay(s3.getObject(path.root, path.key).getObjectContent)
+    fs2.io.readInputStream(is, chunkSize, closeAfterUse = true, blocker = blocker)
   }
 
-  override def put(path: Path): Sink[F, Byte] = { in =>
+  override def put(path: Path): Pipe[F, Byte, Unit] = { in =>
     val init: F[(PipedOutputStream, PipedInputStream)] = F.delay {
       val os = new PipedOutputStream()
       val is = new PipedInputStream(os)
@@ -78,17 +76,17 @@ final class S3Store[F[_]](transferManager: TransferManager, objectAcl: Option[Ca
     }
 
     val consume: ((PipedOutputStream, PipedInputStream)) => Stream[F, Unit] = ios => {
-      val putToS3 = Stream.eval(CS.evalOn(blockingExecutionContext)(F.delay {
+      val putToS3 = Stream.eval(blocker.delay{
         val meta = new ObjectMetadata()
         path.size.foreach(meta.setContentLength)
         sseAlgorithm.foreach(meta.setSSEAlgorithm)
         transferManager.upload(path.root, path.key, ios._2, meta).waitForCompletion()
         objectAcl.foreach(acl => s3.setObjectAcl(path.root, path.key, acl))
         ()
-      }))
+      })
 
       val writeBytes: Stream[F, Unit] =
-        _writeAllToOutputStream1(in, ios._1, blockingExecutionContext).stream ++ Stream.eval(F.delay(ios._1.close()))
+        _writeAllToOutputStream1(in, ios._1, blocker).stream ++ Stream.eval(F.delay(ios._1.close()))
 
       putToS3 concurrently writeBytes
     }
@@ -106,14 +104,14 @@ final class S3Store[F[_]](transferManager: TransferManager, objectAcl: Option[Ca
     _ <- remove(src)
   } yield ()
 
-  override def copy(src: Path, dst: Path): F[Unit] = CS.evalOn(blockingExecutionContext)(F.delay {
+  override def copy(src: Path, dst: Path): F[Unit] = blocker.delay {
     val meta = new ObjectMetadata()
     sseAlgorithm.foreach(meta.setSSEAlgorithm)
     val req = new CopyObjectRequest(src.root, src.key, dst.root, dst.key).withNewObjectMetadata(meta)
     transferManager.copy(req).waitForCompletion()
-  })
+  }
 
-  override def remove(path: Path): F[Unit] = CS.evalOn(blockingExecutionContext)(F.delay(s3.deleteObject(path.root, path.key)))
+  override def remove(path: Path): F[Unit] = blocker.delay(s3.deleteObject(path.root, path.key))
 }
 
 object S3Store {
@@ -124,9 +122,9 @@ object S3Store {
     * @param encrypt Boolean true to force all writes to use SSE algorithm ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_] : ContextShift](functor: F[TransferManager], encrypt: Boolean, blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] = {
+  def apply[F[_] : ContextShift](functor: F[TransferManager], encrypt: Boolean, blocker: Blocker)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] = {
     val opt = if (encrypt) Option(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION) else None
-    apply(functor, None, opt, blockingExecutionContext)
+    apply(functor, None, opt, blocker)
   }
 
   /**
@@ -138,9 +136,10 @@ object S3Store {
     * @param encrypt Boolean true to force all writes to use SSE algorithm ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_] : ContextShift](encrypt: Boolean, blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] = {
+
+  def apply[F[_] : ContextShift](encrypt: Boolean, blocker: Blocker)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] = {
     val opt = if (encrypt) Option(ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION) else None
-    apply(F.delay(TransferManagerBuilder.standard().build()), None, opt, blockingExecutionContext)
+    apply(F.delay(TransferManagerBuilder.standard().build()), None, opt, blocker)
   }
 
   /**
@@ -152,8 +151,9 @@ object S3Store {
     * @param sseAlgorithm SSE algorithm, ObjectMetadata.AES_256_SERVER_SIDE_ENCRYPTION is recommended.
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_] : ContextShift](sseAlgorithm: String, blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] =
-    apply(F.delay(TransferManagerBuilder.standard().build()), None, Option(sseAlgorithm), blockingExecutionContext)
+  def apply[F[_] : ContextShift](sseAlgorithm: String, blocker: Blocker)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] =
+    apply(F.delay(TransferManagerBuilder.standard().build()), None, Option(sseAlgorithm), blocker)
+
 
 
   /**
@@ -164,8 +164,8 @@ object S3Store {
     *
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_] : ContextShift](blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] =
-    apply(F.delay(TransferManagerBuilder.standard().build()), None, None, blockingExecutionContext)
+  def apply[F[_] : ContextShift](blocker: Blocker)(implicit F: Concurrent[F]): Stream[F, S3Store[F]] =
+    apply(F.delay(TransferManagerBuilder.standard().build()), None, None, blocker)
 
 
 
@@ -176,8 +176,8 @@ object S3Store {
     * @param sseAlgorithm Option[String] Server Side Encryption algorithm
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_]](functor: F[TransferManager], sseAlgorithm: Option[String], blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F]): Stream[F, S3Store[F]] =
-    fs2.Stream.bracket(functor)(tm => F.delay(tm.shutdownNow())).map(tm => new S3Store[F](tm, None, sseAlgorithm, blockingExecutionContext))
+  def apply[F[_]](functor: F[TransferManager], sseAlgorithm: Option[String], blocker: Blocker)(implicit F: Concurrent[F], CS: ContextShift[F]): Stream[F, S3Store[F]] =
+    fs2.Stream.bracket(functor)(tm => F.delay(tm.shutdownNow())).map(tm => new S3Store[F](tm, None, sseAlgorithm, blocker))
 
   /**
     * Safely initialize S3Store and shutdown Amazon S3 client upon finish.
@@ -186,7 +186,7 @@ object S3Store {
     * @param sseAlgorithm Option[String] Server Side Encryption algorithm
     * @return Stream[ F, S3Store[F] ] stream with one S3Store, AmazonS3 client will disconnect once stream is done.
     */
-  def apply[F[_]](functor: F[TransferManager], objectAcl: Option[CannedAccessControlList], sseAlgorithm: Option[String], blockingExecutionContext: ExecutionContext)(implicit F: Concurrent[F], CS: ContextShift[F]): Stream[F, S3Store[F]] =
-    fs2.Stream.bracket(functor)(tm => F.delay(tm.shutdownNow())).map(tm => new S3Store[F](tm, objectAcl, sseAlgorithm, blockingExecutionContext))
+  def apply[F[_]](functor: F[TransferManager], objectAcl: Option[CannedAccessControlList], sseAlgorithm: Option[String], blocker: Blocker)(implicit F: Concurrent[F], CS: ContextShift[F]): Stream[F, S3Store[F]] =
+    fs2.Stream.bracket(functor)(tm => F.delay(tm.shutdownNow())).map(tm => new S3Store[F](tm, objectAcl, sseAlgorithm, blocker))
 
 }

--- a/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
+++ b/s3/src/test/scala/blobstore/s3/S3StoreTest.scala
@@ -42,7 +42,7 @@ class S3StoreTest extends AbstractStoreTest {
     .withS3Client(client)
     .build()
 
-  override val store: Store[IO] = new S3Store[IO](transferManager, blockingExecutionContext = blockingExecutionContext)
+  override val store: Store[IO] = new S3Store[IO](transferManager, blocker = blocker)
   override val root: String = "blobstore-test-bucket"
 
   override def beforeAll(): Unit = {

--- a/sftp/build.sbt
+++ b/sftp/build.sbt
@@ -1,5 +1,5 @@
 name := "sftp"
 
 libraryDependencies ++= Seq(
-  "com.jcraft" % "jsch" % "0.1.50"
+  "com.jcraft" % "jsch" % "0.1.55"
 )

--- a/sftp/src/test/scala/blobstore/sftp/SftpStoreTest.scala
+++ b/sftp/src/test/scala/blobstore/sftp/SftpStoreTest.scala
@@ -48,7 +48,7 @@ class SftpStoreTest extends AbstractStoreTest {
 
   private val rootDir = Paths.get("tmp/sftp-store-root/").toAbsolutePath.normalize
   val mVar = MVar.empty[IO, ChannelSftp].unsafeRunSync()
-  override val store: Store[IO] = new SftpStore[IO]("/", session, blockingExecutionContext, mVar, None, 10000)
+  override val store: Store[IO] = new SftpStore[IO]("/", session, blocker, mVar, None, 10000)
   override val root: String = "sftp_tests"
 
   // remove dirs created by AbstractStoreTest


### PR DESCRIPTION
Cross compile to 2.13, update to scala 2.12.10, sbt 1.3.0, fs2 2.0.1, scalatest 3.2.0-M1, box-java-sdk to 2.41.0, google-cloud-storage 1.98.0, google-cloud-nio 0.116.0-alpha, aws-java-sdk-s3 1.11.659, jsch 0.1.55

Fixes #41