### PR TITLE
Support file not found for GCS

### DIFF
--- a/core/src/test/scala/blobstore/AbstractStoreTest.scala
+++ b/core/src/test/scala/blobstore/AbstractStoreTest.scala
@@ -107,7 +107,7 @@ trait AbstractStoreTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
 
     store.listAll(dir).unsafeRunSync().isEmpty must be(true)
   }
-  
+
   // We've had some bugs involving directories at the root level, since it is a bit of an edge case.
   // Worth noting that that most of these tests operate on files that are in nested directories, avoiding
   // any problems that there might be with operating on a root level file/directory.
@@ -120,7 +120,7 @@ trait AbstractStoreTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       .map(writeFile(store, rootDir))
 
     val exp = paths.map(p => s"${p.key}").toSet
-    
+
     // Not doing equals comparison because this directory contains files from other tests.
     // Also, some stores will prepend a "/" before the filenames. Doing a string comparison to ignore this detail for now.
     val pathsListed = store.listAll(rootDir).unsafeRunSync().map(_.key).toSet.toString()
@@ -289,7 +289,7 @@ trait AbstractStoreTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
     store.list(srcDir)
       .compile.drain.unsafeRunSync().isEmpty must be(true)
   }
-  
+
   it should "succeed on remove when path does not exist" in {
     val dir = dirPath("remove-nonexistent-path")
     val path = dir / "no-file.txt"
@@ -309,6 +309,14 @@ trait AbstractStoreTest extends AnyFlatSpec with Matchers with BeforeAndAfterAll
       res <- store.getContents(path)
       _ <- store.remove(path)
     } yield res must be(exp)
+
+    test.unsafeRunSync()
+  }
+
+  it should "return failed stream when getting non-existing file" in {
+    val test = for {
+      res <- store.get(dirPath("foo") / "doesnt-exists.txt").attempt.compile.lastOrError
+    } yield res mustBe a[Left[_, _]]
 
     test.unsafeRunSync()
   }

--- a/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
+++ b/gcs/src/main/scala/blobstore/gcs/GcsStore.scala
@@ -1,13 +1,15 @@
 package blobstore.gcs
 
+import java.io.InputStream
 import java.nio.channels.Channels
 import java.time.Instant
 import java.util.Date
 
 import blobstore.{Path, Store}
 import cats.effect.{Blocker, ContextShift, Sync}
+import cats.syntax.applicative._
 import com.google.api.gax.paging.Page
-import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, Storage}
+import com.google.cloud.storage.{Acl, Blob, BlobId, BlobInfo, Storage, StorageException}
 import com.google.cloud.storage.Storage.{BlobListOption, CopyRequest}
 import fs2.{Chunk, Pipe, Stream}
 
@@ -43,8 +45,14 @@ final class GcsStore[F[_]](storage: Storage, blocker: Blocker, acls: List[Acl] =
   }
 
   def get(path: Path, chunkSize: Int): fs2.Stream[F, Byte] = {
-    val is = blocker.delay(Channels.newInputStream(storage.get(path.root, path.key).reader()))
-    fs2.io.readInputStream(is, chunkSize, blocker, closeAfterUse = true)
+    val is: F[Option[InputStream]] = blocker.delay {
+      Option(storage.get(path.root, path.key)).map(blob => Channels.newInputStream(blob.reader()))
+    }
+
+    Stream.eval(is).flatMap {
+      case Some(is) => fs2.io.readInputStream(is.pure[F], chunkSize, blocker, closeAfterUse = true)
+      case None => Stream.raiseError[F](new StorageException(404, s"Object not found, $path"))
+    }
   }
 
   def put(path: Path): Pipe[F, Byte, Unit] = {


### PR DESCRIPTION
Fetching non-existing files from GCS currently fails with

```
java.lang.NullPointerException
	at blobstore.gcs.GcsStore.$anonfun$get$1(GcsStore.scala:46)
	at cats.effect.internals.IORunLoop$.cats$effect$internals$IORunLoop$$loop(IORunLoop.scala:87)
	at cats.effect.internals.IORunLoop$.startCancelable(IORunLoop.scala:41)
```

This PR makes the GcsStore consistent with the other stores and fails the stream instead