### PR TITLE
Update fs2 to version 2.2.2, remove scala 2.11 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -88,7 +88,7 @@ consistent with all other `Store` implementations.
 Tests are set up to run via docker-compose:
 
 ```bash
-docker-compose run --rm sbt "testOnly * -- -l blobstore.IntegrationTest"
+docker-compose run --rm sbt "+testOnly * -- -l blobstore.IntegrationTest"
 ```
 
 This will start a [minio](https://www.minio.io/docker.html) (Amazon S3 compatible 

--- a/build.sbt
+++ b/build.sbt
@@ -2,7 +2,7 @@ name := "fs2-blobstore"
 
 inThisBuild(Seq(
   scalaVersion := "2.12.10",
-  crossScalaVersions := Seq("2.11.12", "2.12.10", "2.13.0"),
+  crossScalaVersions := Seq("2.12.10", "2.13.0"),
   organization := "com.lendup.fs2-blobstore"
 ))
 

--- a/core/build.sbt
+++ b/core/build.sbt
@@ -1,12 +1,12 @@
 name := "core"
 
-val fs2Version = "2.0.1"
+val fs2Version = "2.2.2"
 
 libraryDependencies ++= Seq(
   "co.fs2" %% "fs2-core" % fs2Version,
   "co.fs2" %% "fs2-io" % fs2Version,
   "org.scalatest" %% "scalatest" % "3.2.0-M1" % "test",
-  "org.typelevel" %% "cats-effect-laws" % "2.0.0" % "test"
+  "org.typelevel" %% "cats-effect-laws" % "2.1.1" % "test"
 ) ++ (CrossVersion.partialVersion(scalaVersion.value) match {
   case Some((2, x)) if x < 13 =>
     "org.scala-lang.modules" %% "scala-collection-compat" % "2.1.2" :: Nil

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,7 +23,7 @@ services:
     command: "server /data"
 
   sbt:
-    image: hseeberger/scala-sbt:8u171_2.12.6_1.2.1
+    image: hseeberger/scala-sbt:8u242_1.3.8_2.12.10
 
     entrypoint: /usr/bin/sbt
     working_dir: /opt/app


### PR DESCRIPTION
This brings fs2 up to the latest version, but that means dropping support for scala 2.11 as fs2 dropped support from version 2.2.0. There probably needs some discussion as to whether people are still using 2.11.

The big advantage of the update is that it aligns the fs2 version with the version used by http4s 0.21.x.  http4s 0.20.x still uses fs2 1.0.5 so at present there is not a version of fs2-blobstore that aligns with a production version of http4s.